### PR TITLE
custom redirect_uri, onCancel handler, token request issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ const CREDENTIAILS = {
 };
 
 export default class azureAuth extends React.Component {
-	constructor(props){
-		super(props);
-		
-		this.azureInstance = new AzureInstance(CREDENTIAILS);
+    constructor(props){
+        super(props);
+        
+        this.azureInstance = new AzureInstance(CREDENTIAILS);
         this._onLoginSuccess = this._onLoginSuccess.bind(this);
-		this._onLoginCancel = this._onLoginCancel.bind(this);
-	}
+        this._onLoginCancel = this._onLoginCancel.bind(this);
+    }
     
     _onLoginSuccess(){
         this.azureInstance.getUserInfo().then(result => {
@@ -103,18 +103,18 @@ export default class azureAuth extends React.Component {
             console.log(err);
         })
     }
-	
-	_onLoginCancel(){
-		// Show cancel message
-	}
+    
+    _onLoginCancel(){
+        // Show cancel message
+    }
 
     render() {
         return (
             <AzureLoginView
-            	azureInstance={this.azureInstance}
-            	loadingMessage="Requesting access token"
+                azureInstance={this.azureInstance}
+                loadingMessage="Requesting access token"
                 onSuccess={this._onLoginSuccess}
-            	onCancel={this._onLoginCancel}
+                onCancel={this._onLoginCancel}
             />
         );
     }

--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ render( ) {
     );
 }
 ```
+If you get an error about invalid token you can set the `excludeSecretFromTokenRequest` prop to `true`.
+
+```javascript
+render( ) {
+    return (
+        <AzureLoginView
+            azureInstance={this.azureInstance}
+            loadingMessage="Requesting access token"
+            onSuccess={this._onLoginSuccess}
+            onCancel={this._onLoginCancel}
+            excludeSecretFromTokenRequest={true}
+        />
+    );
+}
+```
 When combine all parts together, it will look like this.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Then create an AzureInstance by using Microsoft application credential that we h
 const CREDENTIAILS = {
     client_id: 'xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
     client_secret: 'xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    redirect_uri: 'xxxx',
     scope: 'User.ReadBasic.All Mail.Read offline_access'
 };
 
@@ -51,6 +52,7 @@ render( ) {
             azureInstance={this.azureInstance}
             loadingMessage="Requesting access token"
             onSuccess={this._onLoginSuccess}
+            onCancel={this._onLoginCancel}
         />
     );
 }
@@ -66,6 +68,7 @@ import {AzureInstance, AzureLoginView} from './azure';
 const CREDENTIAILS = {
     client_id: 'xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
     client_secret: 'xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    redirect_uri: 'xxxx',
     scope: 'User.ReadBasic.All Mail.Read offline_access'
 };
 
@@ -74,15 +77,20 @@ export default class azureAuth extends React.Component {
 		super(props);
 		
 		this.azureInstance = new AzureInstance(CREDENTIAILS);
-		this._onLoginSuccess = this._onLoginSuccess.bind(this);
+        this._onLoginSuccess = this._onLoginSuccess.bind(this);
+		this._onLoginCancel = this._onLoginCancel.bind(this);
 	}
+    
+    _onLoginSuccess(){
+        this.azureInstance.getUserInfo().then(result => {
+            console.log(result);
+        }).catch(err => {
+            console.log(err);
+        })
+    }
 	
-	_onLoginSuccess(){
-		this.azureInstance.getUserInfo().then(result => {
-			console.log(result);
-		}).catch(err => {
-			console.log(err);
-		})
+	_onLoginCancel(){
+		// Show cancel message
 	}
 
     render() {
@@ -90,7 +98,8 @@ export default class azureAuth extends React.Component {
             <AzureLoginView
             	azureInstance={this.azureInstance}
             	loadingMessage="Requesting access token"
-            	onSuccess={this._onLoginSuccess}
+                onSuccess={this._onLoginSuccess}
+            	onCancel={this._onLoginCancel}
             />
         );
     }

--- a/README.md
+++ b/README.md
@@ -57,21 +57,6 @@ render( ) {
     );
 }
 ```
-If you get an error about invalid token you can set the `excludeSecretFromTokenRequest` prop to `true`.
-
-```javascript
-render( ) {
-    return (
-        <AzureLoginView
-            azureInstance={this.azureInstance}
-            loadingMessage="Requesting access token"
-            onSuccess={this._onLoginSuccess}
-            onCancel={this._onLoginCancel}
-            excludeSecretFromTokenRequest={true}
-        />
-    );
-}
-```
 When combine all parts together, it will look like this.
 
 ```javascript

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -97,7 +97,7 @@ export default class Auth {
             });
     }
 
-    getTokenFromCode(code: string, excludeSecret: bool): Promise {
+    getTokenFromCode(code: string): Promise {
         var params = {
             client_id: this.client_id,
             client_secret: this.client_secret,
@@ -107,10 +107,6 @@ export default class Auth {
             response_mode: 'form_post',
             nonce: uuid.v4(),
             state: 'abcd'
-        };
-
-        if(excludeSecret === true) {
-            delete params.client_secret;
         }
 
         return this._request(params);

--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -97,7 +97,7 @@ export default class Auth {
             });
     }
 
-    getTokenFromCode(code: string): Promise {
+    getTokenFromCode(code: string, excludeSecret: bool): Promise {
         var params = {
             client_id: this.client_id,
             client_secret: this.client_secret,
@@ -107,6 +107,10 @@ export default class Auth {
             response_mode: 'form_post',
             nonce: uuid.v4(),
             state: 'abcd'
+        };
+
+        if(excludeSecret === true) {
+            delete params.client_secret;
         }
 
         return this._request(params);

--- a/lib/AzureInstance.js
+++ b/lib/AzureInstance.js
@@ -2,7 +2,7 @@ export default class AzureInstance {
     constructor(credentials) {
         this.authority = 'https://login.microsoftonline.com/common';
         this.authorize_endpoint = '/oauth2/v2.0/authorize';
-        this.redirect_uri = 'https://localhost:3000/login';
+        this.redirect_uri = credentials.redirect_uri || 'https://localhost:3000/login';
         this.token_endpoint ='/oauth2/v2.0/token';
         this.client_id = credentials.client_id;
         this.client_secret = credentials.client_secret;

--- a/lib/AzureLoginView.js
+++ b/lib/AzureLoginView.js
@@ -17,19 +17,21 @@ import Auth from './Auth';
 export default class AzureLoginView extends React.Component {
 	props : {
 		azureInstance: AzureInstance,
-		onSuccess? : ?Function
+		onSuccess? : ?Function,
+		onCancel? : ?Function,
 	};
 
 	state : {
-	    visible: bool
-  	};
+		visible: bool,
+	};
 
 	constructor(props:any){
 		super(props);
 
 		this.auth = new Auth(this.props.azureInstance);
 		this.state = {
-			visible: true
+			visible: true,
+			cancelled: false,
 		}
 
 		this._handleTokenRequest = this._handleTokenRequest.bind(this);
@@ -52,33 +54,41 @@ export default class AzureLoginView extends React.Component {
 				// call success handler
 				this.props.onSuccess();
 			})
-			.catch((err) => {
-        		throw new Error(err);
-      		})
+				.catch((err) => {
+					throw new Error(err);
+				})
 		}
-  	}
 
-  	_renderLoadingView(){
-  		return this.props.loadingView === undefined ? (
-  			<View
-  				style={[this.props.style, styles.loadingView, 
-  					{
+		// if user cancels the process before finishing
+		if(!this.state.cancelled && this.props.onCancel && e.url.indexOf('error=access_denied') > -1) {
+			this.setState({cancelled: true, visible: false});
+
+			// call cancel handler
+			this.props.onCancel();
+		}
+	}
+
+	_renderLoadingView(){
+		return this.props.loadingView === undefined ? (
+			<View
+				style={[this.props.style, styles.loadingView,
+					{
 						flex:1,
 						alignSelf : 'stretch',
 						width : Dimensions.get('window').width,
 						height : Dimensions.get('window').height
 					}
 				]}
-  			>
-  				<Text>{this.props.loadingMessage}</Text>
-  			</View>
-  		) : this.props.loadingView
-  	}
+			>
+				<Text>{this.props.loadingMessage}</Text>
+			</View>
+		) : this.props.loadingView
+	}
 
 	render() {
 		let js = `document.getElementsByTagName('body')[0].style.height = '${Dimensions.get('window').height}px';`
 
-   		return (
+		return (
 			this.state.visible ? (
 				<WebView
 					automaticallyAdjustContentInsets={true}
@@ -100,7 +110,7 @@ export default class AzureLoginView extends React.Component {
 					scalesPageToFit={true}
 				/> ) : this._renderLoadingView()
 		)
-   	}
+	}
 
 }
 

--- a/lib/AzureLoginView.js
+++ b/lib/AzureLoginView.js
@@ -47,7 +47,7 @@ export default class AzureLoginView extends React.Component {
 			this.setState({visible : false})
 
 			// request for a token
-			this.auth.getTokenFromCode(code).then(token => {
+			this.auth.getTokenFromCode(code, this.props.excludeSecretFromTokenRequest).then(token => {
 				// set token to instance
 				this.props.azureInstance.setToken(token);
 

--- a/lib/AzureLoginView.js
+++ b/lib/AzureLoginView.js
@@ -47,7 +47,7 @@ export default class AzureLoginView extends React.Component {
 			this.setState({visible : false})
 
 			// request for a token
-			this.auth.getTokenFromCode(code, this.props.excludeSecretFromTokenRequest).then(token => {
+			this.auth.getTokenFromCode(code).then(token => {
 				// set token to instance
 				this.props.azureInstance.setToken(token);
 


### PR DESCRIPTION
added option to pass custom redirect_uri
added onCancel handler for when user cancels login process before finishing
added option to exclude client secret when fetching token, (some users have had errors regarding this)