### PR TITLE
Fix refresh token function

### DIFF
--- a/lib/Auth.js
+++ b/lib/Auth.js
@@ -116,7 +116,7 @@ export default class Auth {
         var params = {
             client_id: this.client_id,
             client_secret: this.client_secret,
-            refresh_token: code,
+            refresh_token: refreshToken,
             grant_type: 'refresh_token',
             redirect_uri: this.redirect_uri,
             response_mode: 'form_post',


### PR DESCRIPTION
The getTokenFromRefreshToken was using an undefined variable.
Fast fix, using "refreshToken" instead of "code".